### PR TITLE
[Fix] Do not redirect to the admin user profile after updating a user note

### DIFF
--- a/src/store/user/index.js
+++ b/src/store/user/index.js
@@ -89,7 +89,7 @@ const actions = {
 
   update ({ dispatch }, { params, userId }) {
     return dispatch('api/admin/put', { url: `/users/${userId}`, params }, { root: true })
-      .then(() => dispatch('get'))
+      .then(() => dispatch('get', { userId }))
   },
 
   fillUserData ({ commit }, data) {


### PR DESCRIPTION
By default, the loaded user profile is the one related to the user ID found in the JWT ; an administrator has to specify the user ID he wants to display the profile.