### PR TITLE
Support for Internet exmplorer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1338,6 +1338,23 @@
         "babel-types": "6.26.0"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.1",
+        "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
     "babel-preset-env": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "axios": "^0.16.2",
+    "babel-polyfill": "^6.26.0",
     "chart.js": "^2.7.2",
     "d3": "3.5.17",
     "es6-promise": "^4.2.4",

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import VeeValidate from 'vee-validate'
 import VueClipboard from 'vue-clipboard2'
 import router from './router'
 import store from './store'
+import 'babel-polyfill'
 import Vuetify from 'vuetify'
 
 import 'template.data.gouv.fr/dist/style/main.css'


### PR DESCRIPTION
Avec l'ajout de Vuetify le dashboard ne fonctionne plus sur IE.

Il y a un patch, j'ai mis la solution officielle de Vuetify (et compatible vue-cli 3)

=> motif de ce dev : une cliente n'arrive pas à afficher le dashboard...