### PR TITLE
Sanitize incoming user/index data for null

### DIFF
--- a/src/components/mixins/data.js
+++ b/src/components/mixins/data.js
@@ -1,0 +1,14 @@
+export const sanitizeNulls = function(data) {
+  return data.map(obj => {
+    replaceNulls(obj);
+  });
+};
+
+// "== null" => test for null or undefined
+function replaceNulls(obj) {
+  Object.keys(obj).map(key => {
+    if (obj[key] == null) {
+      obj[key] = "";
+    }
+  });
+}

--- a/src/store/user/index/index.js
+++ b/src/store/user/index/index.js
@@ -1,4 +1,5 @@
 import orderBy from "lodash/orderBy";
+import { sanitizeNulls } from "@/components/mixins/data";
 
 const state = {
   userIndex: [],
@@ -70,6 +71,7 @@ const mutations = {
 const actions = {
   index({ commit, dispatch }) {
     dispatch("api/admin/get", { url: "/users" }, { root: true }).then(data => {
+      sanitizeNulls(data);
       // Default order: by most recent
       data = orderBy(data, "created_at", "desc");
       commit("fill", data);


### PR DESCRIPTION
Instead of guarding-clause every method and ending
up with spaghetti code, it seems more logical/clear/concise
to sanitize any incoming data against null cases.
null or undefined will therefore be replaced with empty string.

(NB : Manière de faire un peu non-orthodoxe ici, je m'attend à ce que cela choque et suis ouvert à la discussion)