### PR TITLE
Données de contact dans le formulaire de création de JWT

### DIFF
--- a/src/components/resource/jwt_api_entreprise/New.vue
+++ b/src/components/resource/jwt_api_entreprise/New.vue
@@ -2,21 +2,39 @@
 .dialog
   button.button.small.title-button(@click="showDialog") Ajouter un token
   .dialog-backdrop(v-if="dialog")
-    .dialog.panel
-      h2 Ajout d’un nouveau token
-      .form__group
-        label(for="agent-name") Organisme utilisateur final (ex: numéro SIRET)
-        input(type="text" v-model="subject" id="agent-name")
+    .dialog__full
+      .dialog__jwt_data
+        .dialog.panel
+          h2 Ajout d’un nouveau token
+          .form__group
+            label(for="agent-name") Organisme utilisateur final (ex: numéro SIRET)
+            input(type="text" v-model="subject" id="agent-name")
 
-      .form__group
-        label Rôles d’accès
-        div(v-for="role in allRoles")
-          input(type="checkbox" :id="role.code" v-model="checked_roles" :value="role.code")
-          label.label-inline(:for="role.code") {{role.name}}
+          .form__group
+            label Rôles d’accès
+            div(v-for="role in allRoles")
+              input(type="checkbox" :id="role.code" v-model="checked_roles" :value="role.code")
+              label.label-inline(:for="role.code") {{role.name}}
+      .dialog__contacts.panel
+        .form__group
+          h4 Contact administratif
+          label(for="admin-email") Adresse Email
+          input(type="text" id="admin-email" v-model="admin_contact.email")
 
-      .action-buttons
-        button.button.small(@click="submit") Créer
-        button.button.small.warning(@click="reset") Annuler
+          label(for="admin-phone") Numéro de téléphone
+          input(type="text" id="admin-phone" v-model="admin_contact.phone_number")
+
+        .form__group
+          h4 Contact technique
+          label(for="tech-email") Adresse Email
+          input(type="text" id="tech-email" v-model="tech_contact.email")
+
+          label(for="tech-phone") Numéro de téléphone
+          input(type="text" id="tech-phone" v-model="tech_contact.phone_number")
+
+        .action-buttons
+          button.button.small(@click="submit") Créer
+          button.button.small.warning(@click="reset") Annuler
 
 </template>
 
@@ -29,7 +47,17 @@ export default {
     return {
       dialog: false,
       subject: "",
-      checked_roles: []
+      checked_roles: [],
+      admin_contact: {
+        email: "",
+        phone_number: "",
+        contact_type: "admin"
+      },
+      tech_contact: {
+        email: "",
+        phone_number: "",
+        contact_type: "tech"
+      }
     };
   },
 
@@ -41,9 +69,14 @@ export default {
 
   methods: {
     submit: function() {
-      let payload = {
-        roles: this.checked_roles,
-        subject: this.subject
+      const formatedRolesList = this.checked_roles.map(function(codeValue) {
+        return { code: codeValue };
+      });
+
+      const payload = {
+        roles: formatedRolesList,
+        subject: this.subject,
+        contacts: [this.admin_contact, this.tech_contact]
       };
 
       this.$store
@@ -56,6 +89,8 @@ export default {
 
     reset: function() {
       this.checked_roles = [];
+      this.admin_contact.email = this.admin_contact.phone_number = "";
+      this.tech_contact.email = this.tech_contact.phone_number = "";
       this.dialog = false;
       this.subject = "";
     },
@@ -83,6 +118,24 @@ label.label-inline {
   justify-content: center;
   align-items: center;
   z-index: 100;
+}
+
+.dialog__full {
+  display: grid;
+  grid-template-columns: 50% 50%;
+}
+
+.dialog__jwt_data {
+  grid-column-start: 1;
+  grid-column-end: 2;
+}
+
+.dialog__contacts {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  grid-column-start: 2;
+  grid-column-end: 3;
 }
 
 .dialog {

--- a/src/store/user/index.js
+++ b/src/store/user/index.js
@@ -157,7 +157,7 @@ const actions = {
     commit("setAllowedRoles", data.allowed_roles);
   },
 
-  createToken({ dispatch, commit, getters }, payload) {
+  createToken({ dispatch, getters }, payload) {
     const userId = getters.userDetails.id;
     //TODO not RESTFull here since a post on the resource URL is already
     //a "create" action. Authorizations (here checking this is an admin

--- a/src/store/user/index.js
+++ b/src/store/user/index.js
@@ -163,13 +163,13 @@ const actions = {
     //a "create" action. Authorizations (here checking this is an admin
     //making the request) needs to be done server side.
     //The URL should be /users/${userId}/jwt_api_entreprise
-    let url = `/users/${userId}/jwt_api_entreprise/admin_create`;
+    let url = `/users/${userId}/jwt_api_entreprise`;
 
     dispatch(
       "api/admin/post",
       { url: url, params: payload },
       { root: true }
-    ).then(data => commit("addToken", data.new_token));
+    ).then(() => dispatch("get", { userId }));
   },
 
   blacklistToken({ dispatch, getters }, payload) {


### PR DESCRIPTION
Contacts are related to JWTs now and therefore need to be created
alonside tokens.

* roles list must now respect the `[{ code: 'veryrole' }, ...]` format for
backend compatibility ;
* only the JWT (the hash) is returned in the response of the create
request, we now need to reload the user details to get the contact's
data.

Here is a screenshot: 

<img width="726" alt="Capture d’écran 2019-10-22 à 16 53 52" src="https://user-images.githubusercontent.com/4283958/67303232-7002b780-f4f2-11e9-94f4-0a70aaf18574.png">