### PR TITLE
Arrange la disposition des tuiles de contact

### DIFF
--- a/src/components/resource/contact/Show.vue
+++ b/src/components/resource/contact/Show.vue
@@ -48,7 +48,7 @@ export default {
 
 <style lang="scss" scoped>
 .panel {
-  flex: 1;
+  width: 100%;
 }
 
 h4 {

--- a/src/components/resource/user/UserContacts.vue
+++ b/src/components/resource/user/UserContacts.vue
@@ -5,7 +5,7 @@
       template(v-if="anyContacts")
         div(v-for="jwtContacts in accountContacts" class="usage")
           h3 Cadre d'utilisation associé : {{ jwtContacts.usage_policy }}
-          .contact__container.row
+          .contact__container.grid
             contact-tile(class="contact" v-for="(contact, index) in jwtContacts.contacts_data" :contact="contact" :key="index")
 
       div(v-else) Aucune coordonnée de contact


### PR DESCRIPTION
Remplace `flex` par `grid` pour une disposition automatique lorsque le nombre de tuiles dépasse la capacité d'une ligne.

Closes #20 

![image](https://user-images.githubusercontent.com/1301085/70916929-bb31d600-201c-11ea-8048-7919ef9e1d67.png)
