### PR TITLE
Actions d'archivage et de blacklistage de jetons

### DIFF
--- a/src/components/resource/jwt_api_entreprise/Show.vue
+++ b/src/components/resource/jwt_api_entreprise/Show.vue
@@ -76,7 +76,7 @@
           Blacklister
         </button>
         <button
-          v-if="!jwt.blacklisted && isAdmin"
+          v-if="!jwt.archived && isAdmin"
           class="button secondary"
           @click="dialogArchiveJwt = true"
         >
@@ -162,13 +162,13 @@ export default {
 
     blacklistJwt() {
       this.$store
-        .dispatch("user/blacklistToken", { id: this.jwt.payload.jti })
+        .dispatch("user/blacklistToken", this.jwt.payload.jti)
         .finally((this.dialogBlacklistJwt = false));
     },
 
     archiveJwt() {
       this.$store
-        .dispatch("user/archiveToken", { id: this.jwt.payload.jti })
+        .dispatch("user/archiveToken", this.jwt.payload.jti)
         .finally((this.dialogArchiveJwt = false));
     }
   }

--- a/src/components/resource/user/UserTokens.vue
+++ b/src/components/resource/user/UserTokens.vue
@@ -3,11 +3,16 @@
     h2(class="main-title") Tokens de l’organisation
     jwt-api-entreprise-new(v-if="isAdmin")
 
-    div(v-if="tokens.length > 0 || blacklistedTokens.length > 0")
+    div(v-if="tokens.length > 0 || blacklistedTokens.length > 0 || archivedTokens.length > 0")
       jwt-api-entreprise-index(:jwtList="tokens" v-if="tokens.length > 0")
+
       div(v-if="isAdmin && blacklistedTokens.length > 0")
         h2 Tokens blacklistés
         jwt-api-entreprise-index(:jwtList="blacklistedTokens")
+
+      div(v-if="isAdmin && archivedTokens.length > 0")
+        h2 Tokens archivés
+        jwt-api-entreprise-index(:jwtList="archivedTokens")
     p(v-else) Aucun token attribué
 
 </template>
@@ -24,6 +29,7 @@ export default {
     ...mapGetters({
       tokens: "user/tokens",
       blacklistedTokens: "user/blacklistedTokens",
+      archivedTokens: "user/archivedTokens",
       isAdmin: "auth/isAdmin"
     })
   },

--- a/src/store/api/admin/index.js
+++ b/src/store/api/admin/index.js
@@ -40,6 +40,15 @@ const actions = {
     });
   },
 
+  patch(_ctx, { url, params = {} }) {
+    return new Promise((resolve, reject) => {
+      http
+        .patch(url, params)
+        .then(response => resolve(response.data))
+        .catch(error => reject(handleError(error)));
+    });
+  },
+
   updateAuthorizationBearer(_ctx) {
     http.defaults.headers["Authorization"] = "Bearer " + localStorage.token;
   }

--- a/src/store/user/index.js
+++ b/src/store/user/index.js
@@ -9,7 +9,8 @@ const state = {
     contacts: [],
     allowed_roles: [],
     tokens: [],
-    blacklistedTokens: []
+    blacklistedTokens: [],
+    archivedTokens: []
   }
 };
 
@@ -39,6 +40,14 @@ const getters = {
   blacklistedTokens(state) {
     let blacklistedTokens = cloneDeep(state.user.blacklistedTokens);
     return blacklistedTokens.sort(
+      (token1, token2) =>
+        new Date(token2.payload.iat) - new Date(token1.payload.iat)
+    );
+  },
+
+  archivedTokens(state) {
+    let archivedTokens = cloneDeep(state.user.archivedTokens);
+    return archivedTokens.sort(
       (token1, token2) =>
         new Date(token2.payload.iat) - new Date(token1.payload.iat)
     );
@@ -105,6 +114,12 @@ const mutations = {
     state.user.blacklistedTokens = decodedTokens;
   },
 
+  setArchivedTokens(state, archivedTokens) {
+    const decodedTokens = archivedTokens.map(e => formatJwt(e, true));
+
+    state.user.archivedTokens = decodedTokens;
+  },
+
   setAllowedRoles(state, roles) {
     state.user.allowed_roles = roles;
   },
@@ -143,6 +158,7 @@ const actions = {
     commit("setContacts", data.contacts);
     commit("setTokens", data.tokens);
     commit("setBlacklistedTokens", data.blacklisted_tokens);
+    commit("setArchivedTokens", data.archived_tokens);
     commit("setAllowedRoles", data.allowed_roles);
   },
 
@@ -161,22 +177,22 @@ const actions = {
     ).then(() => dispatch("get", { userId }));
   },
 
-  blacklistToken({ dispatch, getters }, payload) {
+  blacklistToken({ dispatch, getters }, jwtId) {
     const userId = getters.userDetails.id;
-    let url = `users/${userId}/jwt_api_entreprise/blacklist`;
+    let url = `jwt_api_entreprise/${jwtId}`;
     dispatch(
-      "api/admin/post",
-      { url: url, params: payload },
+      "api/admin/patch",
+      { url: url, params: { blacklisted: true } },
       { root: true }
     ).then(() => dispatch("get", { userId }));
   },
 
-  archiveToken({ dispatch, getters }, payload) {
+  archiveToken({ dispatch, getters }, jwtId) {
     const userId = getters.userDetails.id;
-    let url = `users/${userId}/jwt_api_entreprise/archive`;
+    let url = `jwt_api_entreprise/${jwtId}`;
     dispatch(
-      "api/admin/post",
-      { url: url, params: payload },
+      "api/admin/patch",
+      { url: url, params: { archived: true } },
       { root: true }
     ).then(() => dispatch("get", { userId }));
   },


### PR DESCRIPTION
### Contenu de la PR 
Les boutons "Archiver" et "Blacklister" un jeton son maintenant fonctionnels pour un administrateur ! Les jetons sont aussi affichés dans des listes différentes en fonction de leur état.