### PR TITLE
Re-enable provider availability

### DIFF
--- a/src/components/dashboard/EndpointHistoryElement.vue
+++ b/src/components/dashboard/EndpointHistoryElement.vue
@@ -22,7 +22,7 @@
         .square(:style="{ 'background-color': color_512 }")
         span DOWN (y compris API de secours)
 
-      <!-- <p>Disponibilité sur 7 jours: <span :class="slaRatingClass">{{ meanSla }}%</span></p> -->
+      <p>Disponibilité sur 7 jours: <span :class="slaRatingClass">{{ meanSla }}%</span></p>
       p(:id="providerName")
         <!-- Visavail.js chart will be inserted here -->
 
@@ -102,9 +102,9 @@ export default {
     },
     slaRatingClass: function() {
       switch (true) {
-        case this.meanSla > 99.8:
+        case this.meanSla > 99:
           return "perfect-sla";
-        case this.meanSla > 98:
+        case this.meanSla > 95:
           return "almost-perfect-sla";
         default:
           return "bad-sla";

--- a/src/style/_variables.scss
+++ b/src/style/_variables.scss
@@ -12,7 +12,7 @@ $color-blue: #0053B3;
 $color-light-blue: #006be6;
 $color-dark-blue: #003b80;
 
-$color-green: #03BD5B;
+$color-green: #5CB85C;
 $color-light-green: #DAF5E7;
 $color-orange: #FF9947;
 $color-light-orange: #FFF0E4;


### PR DESCRIPTION
Ajout de la "disponibilité sur 7 jours" ; trois couleurs :
- vert > 99% (corrigé c'est le même vert que pour "UP")
- orange > 95
- rouge

![image](https://user-images.githubusercontent.com/5159985/73262883-f3116900-41d7-11ea-9baa-f9f598615f40.png)
