### PR TITLE
Add button to renew or extend a token

### DIFF
--- a/src/components/resource/jwt_api_entreprise/Show.vue
+++ b/src/components/resource/jwt_api_entreprise/Show.vue
@@ -75,6 +75,14 @@
         </button>
 
         <button
+          v-if="jwtEligibleForRenew"
+          class="button secondary"
+          @click="redirectToDataPassForm"
+        >
+          Renouveler ou étendre mes droits
+        </button>
+
+        <button
           v-if="!jwt.blacklisted && isAdmin"
           class="button warning"
           @click="modalBlacklistJwt = true"
@@ -162,6 +170,14 @@ export default {
 
     hasAuthorizationRequestId() {
       return this.jwt.authorization_request_id != undefined;
+    },
+
+    jwtEligibleForRenew() {
+      return (
+        !this.jwt.archived &&
+        !this.jwt.blacklisted &&
+        this.hasAuthorizationRequestId
+      );
     }
   },
 
@@ -190,6 +206,13 @@ export default {
       this.$store
         .dispatch("user/archiveToken", this.jwt.id)
         .finally((this.dialogArchiveJwt = false));
+    },
+
+    redirectToDataPassForm() {
+      const redirectUrl =
+        "https://datapass.api.gouv.fr/copy-authorization-request/" +
+        this.jwt.authorization_request_id;
+      window.location = redirectUrl;
     }
   },
 


### PR DESCRIPTION
@DorineLam suite à notre discussion d'hier 

Comme je le disais sur Basecamp il y a plusieurs possibilités pour les jetons historiques obtenus via DS : 
1. Pas de bouton (c'est ce que j'ai implémenté ici, dis moi si tu souhaites la solution 2. ou 3.) 
2. Bouton vers un formulaire vide DataPass de nouvelle demande
3. Bouton vers la doc "première demande de jeton" (dis moi exactement la partie de la doc vers laquelle rediriger les usagers) 

Ci-dessous le rendu sur le dashboard : 

<img width="1415" alt="Capture d’écran 2020-10-28 à 18 10 13" src="https://user-images.githubusercontent.com/4283958/97471297-dc579880-1948-11eb-986a-fdb5eae61307.png">