### PR TITLE
Suppression des console.log() qui trainent

### DIFF
--- a/src/components/dashboard/EndpointHistory.vue
+++ b/src/components/dashboard/EndpointHistory.vue
@@ -30,9 +30,7 @@ export default {
 
   methods: {
     loadHistoricalData: function() {
-      this.$store
-        .dispatch("dashboard/providersHistory")
-        .catch(error => console.log(error.message));
+      this.$store.dispatch("dashboard/providersHistory");
     }
   },
 

--- a/src/components/dashboard/RealTime.vue
+++ b/src/components/dashboard/RealTime.vue
@@ -59,13 +59,9 @@ export default {
 
   methods: {
     loadData: function() {
-      this.$store
-        .dispatch("dashboard/endpoints")
-        .catch(error => console.log(error.message));
+      this.$store.dispatch("dashboard/endpoints");
 
-      this.$store
-        .dispatch("dashboard/homepageCode")
-        .catch(error => console.log(error.messsage));
+      this.$store.dispatch("dashboard/homepageCode");
     }
   },
 

--- a/src/store/dashboard/index.js
+++ b/src/store/dashboard/index.js
@@ -34,31 +34,25 @@ export const actions = {
       "api/watchdoge/get",
       { url: "/dashboard/current_status" },
       { root: true }
-    )
-      .then(data => commit("fillEndpoints", { endpoints: data.results }))
-      .catch(error => console.log(error));
+    ).then(data => commit("fillEndpoints", { endpoints: data.results }));
   },
   homepageCode({ dispatch, commit }) {
     dispatch(
       "api/watchdoge/get",
       { url: "/dashboard/homepage_status" },
       { root: true }
-    )
-      .then(data =>
-        commit("fillHomepageCode", { homepageCode: data.results[0].code })
-      )
-      .catch(error => console.log(error));
+    ).then(data =>
+      commit("fillHomepageCode", { homepageCode: data.results[0].code })
+    );
   },
   providersHistory({ dispatch, commit }) {
     dispatch(
       "api/watchdoge/get",
       { url: "/dashboard/availability_history" },
       { root: true }
-    )
-      .then(data =>
-        commit("fillProvidersHistory", { providersHistory: data.results })
-      )
-      .catch(error => console.log(error));
+    ).then(data =>
+      commit("fillProvidersHistory", { providersHistory: data.results })
+    );
   }
 };
 


### PR DESCRIPTION
Les quelques `console.log()` empêchent une compilation correcte avec `npm build`. Ça passe en répétant la commande mais ça a l'air plutôt d'être un bug ou une inconsistance liée à VueJS.

À la vue du reste du code, où les `dispatch()` ne sont jamais traités par un `console.log()`, ça me parait avoir du sens de faire ça pour que tout soit cohérent et que la compilation passe sans râler.