### PR TITLE
Magic links pour partager des jetons

### DIFF
--- a/src/components/resource/jwt_api_entreprise/Show.vue
+++ b/src/components/resource/jwt_api_entreprise/Show.vue
@@ -9,6 +9,7 @@
         >(expire le {{ formatDate(jwt.exp) }})</small
       >
       <router-link
+        v-if="!unknownUser"
         :to="{
           name: statsRoute,
           params: { jwtId: jwt.id, jwtSub: jwt.subject }
@@ -17,7 +18,7 @@
         >Voir les statistiques →</router-link
       >
       <a
-        v-if="hasAuthorizationRequestId"
+        v-if="!unknownUser && hasAuthorizationRequestId"
         class="token-link"
         :href="signupRoute"
         target="_blank"
@@ -74,7 +75,7 @@
           </svg>
         </button>
 
-        <magic-link-new :jwt-id="jwt.id" />
+        <magic-link-new v-if="!unknownUser" :jwt-id="jwt.id" />
 
         <button
           v-if="jwtEligibleForRenew"
@@ -155,7 +156,8 @@ export default {
 
   computed: {
     ...mapGetters({
-      isAdmin: "auth/isAdmin"
+      isAdmin: "auth/isAdmin",
+      unknownUser: "auth/unknownUser"
     }),
 
     statsRoute() {
@@ -177,6 +179,7 @@ export default {
 
     jwtEligibleForRenew() {
       return (
+        !this.unknownUser &&
         !this.jwt.archived &&
         !this.jwt.blacklisted &&
         this.hasAuthorizationRequestId

--- a/src/components/resource/jwt_api_entreprise/Show.vue
+++ b/src/components/resource/jwt_api_entreprise/Show.vue
@@ -74,6 +74,8 @@
           </svg>
         </button>
 
+        <magic-link-new :jwt-id="jwt.id" />
+
         <button
           v-if="jwtEligibleForRenew"
           class="button secondary"
@@ -128,6 +130,7 @@
 <script>
 import { mapGetters } from "vuex";
 import Modal from "@/components/ui/Modal";
+import MagicLinkNew from "@/components/resource/jwt_api_entreprise/magic_link/New";
 
 export default {
   name: "JwtApiEntrepriseShow",
@@ -217,7 +220,8 @@ export default {
   },
 
   components: {
-    modal: Modal
+    modal: Modal,
+    "magic-link-new": MagicLinkNew
   }
 };
 </script>

--- a/src/components/resource/jwt_api_entreprise/magic_link/New.vue
+++ b/src/components/resource/jwt_api_entreprise/magic_link/New.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <button class="button primary" @click="modalMagicLink = true">
-      Partager
+      Transmettre le jeton à mon équipe technique
     </button>
 
     <modal
@@ -11,7 +11,9 @@
       @close="modalMagicLink = false"
     >
       <p slot="modalText">
-        Adresse à laquelle envoyer le jeton par email
+        Adresse e-mail à laquelle un lien d'accès au token, d'une durée de 4 heures, sera envoyé. </br>
+        ⚠️  Votre clé d'accès est unique et privée. L'utilisation de cette fonctionnalité doit avoir pour unique objectif la transmission sécurisée de votre clé à vos services techniques qui intégreront l'API Entreprise. </br>
+        Le renouvellement d’un token est très facile et rapide. C’est pourquoi, si vous avez divulgué votre token par erreur, n’hésitez pas à écrire rapidement à support@entreprise.api.gouv.fr.
       </p>
 
       <input slot="modalForm" v-model="email" type="text" />

--- a/src/components/resource/jwt_api_entreprise/magic_link/New.vue
+++ b/src/components/resource/jwt_api_entreprise/magic_link/New.vue
@@ -1,0 +1,73 @@
+<template>
+  <div>
+    <button class="button primary" @click="modalMagicLink = true">
+      Partager
+    </button>
+
+    <modal
+      v-if="modalMagicLink"
+      :api-errors="apiErrors"
+      @submit="generateMagicLink"
+      @close="modalMagicLink = false"
+    >
+      <p slot="modalText">
+        Adresse à laquelle envoyer le jeton par email
+      </p>
+
+      <input slot="modalForm" v-model="email" type="text" />
+
+      <template slot="confirmText">
+        Envoyer
+      </template>
+    </modal>
+  </div>
+</template>
+
+<script>
+import Modal from "@/components/ui/Modal";
+
+export default {
+  name: "MagicLinkNew",
+
+  props: {
+    jwtId: {
+      type: String,
+      default() {
+        return "";
+      }
+    }
+  },
+
+  data() {
+    return {
+      modalMagicLink: false,
+      email: "",
+      apiErrors: {}
+    };
+  },
+
+  methods: {
+    generateMagicLink: function() {
+      const payload = {
+        id: this.jwtId,
+        email: this.email
+      };
+      this.$store
+        .dispatch("jwt_api_entreprise/createMagicLink", payload)
+        .then(() => this.reset())
+        .catch(errors => (this.apiErrors = errors));
+    },
+
+    reset: function() {
+      this.email = "";
+      this.modalMagicLink = false;
+    }
+  },
+
+  components: {
+    modal: Modal
+  }
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/components/resource/jwt_api_entreprise/magic_link/Show.vue
+++ b/src/components/resource/jwt_api_entreprise/magic_link/Show.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="panel">
+    <div v-if="errorsArePresent" class="notification error">
+      <ul>
+        <li v-for="(errorMsg, fieldKey) in apiErrors" :key="fieldKey">
+          {{ fieldKey }} : {{ errorMsg }}
+        </li>
+      </ul>
+    </div>
+    <jwt-api-entreprise-show v-if="jwtIsPresent" :jwt="jwt" />
+  </div>
+</template>
+
+<script>
+import JwtApiEntrepriseShow from "@/components/resource/jwt_api_entreprise/Show";
+
+export default {
+  name: "JwtApiEntrepriseMagicLinkShow",
+
+  data() {
+    return {
+      jwt: {},
+      apiErrors: {}
+    };
+  },
+
+  computed: {
+    errorsArePresent: function() {
+      const errorsCount = Object.keys(this.apiErrors).length;
+      return errorsCount > 0;
+    },
+
+    jwtIsPresent: function() {
+      return Object.keys(this.jwt).length > 0;
+    }
+  },
+
+  created: function() {
+    this.$store
+      .dispatch("jwt_api_entreprise/retrieveFromMagicLink", {
+        token: this.$route.query.token
+      })
+      .then(data => {
+        this.jwt = data;
+      })
+      .catch(error => {
+        this.apiErrors = error;
+      });
+  },
+
+  components: {
+    "jwt-api-entreprise-show": JwtApiEntrepriseShow
+  }
+};
+</script>
+
+<style lang="scss" scoped></style>

--- a/src/components/ui/Modal.vue
+++ b/src/components/ui/Modal.vue
@@ -1,7 +1,15 @@
 <template>
   <div class="modal-backdrop">
     <div class="modal panel">
+      <div v-if="errorsArePresent" class="notification error">
+        <ul>
+          <li v-for="(errorMsg, fieldKey) in apiErrors" :key="fieldKey">
+            {{ fieldKey }} : {{ errorMsg }}
+          </li>
+        </ul>
+      </div>
       <slot name="modalText">Souhaitez-vous réaliser cette action ?</slot>
+      <slot name="modalForm"></slot>
       <div class="action-buttons">
         <button class="button small" @click="$emit('close')">
           Annuler
@@ -18,7 +26,22 @@
 
 <script>
 export default {
-  name: "Modal"
+  name: "Modal",
+
+  props: {
+    apiErrors: {
+      type: Object,
+      default() {
+        return {};
+      }
+    }
+  },
+
+  computed: {
+    errorsArePresent: function() {
+      return Object.keys(this.apiErrors).length > 0;
+    }
+  }
 };
 </script>
 

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -13,6 +13,7 @@ import RoleNew from "@/components/resource/role/New";
 import JwtStats from "@/components/resource/jwt_api_entreprise/Stats";
 
 import JwtApiEntrepriseList from "@/components/resource/jwt_api_entreprise/List";
+import JwtApiEntrepriseMagicLink from "@/components/resource/jwt_api_entreprise/magic_link/Show";
 
 import Login from "@/components/Login";
 import AuthApiGouv from "@/components/AuthApiGouv";
@@ -47,6 +48,11 @@ const router = new Router({
       path: "/account/password_reset",
       name: "account-password-reset",
       component: PasswordReset
+    },
+    {
+      path: "/magic_link",
+      name: "jwt-magic-link",
+      component: JwtApiEntrepriseMagicLink
     },
     {
       path: "/auth_api_gouv_callback",

--- a/src/store/api/admin/index.js
+++ b/src/store/api/admin/index.js
@@ -59,6 +59,7 @@ const handleError = error => {
   if (!error.response) router.push({ name: "logout" });
   else if (error.response.status === 401) router.push({ name: "logout" });
   else if (error.response.status === 422) return error.response.data.errors;
+  else if (error.response.status === 404) return error.response.data.errors;
 };
 
 export default { namespaced: true, actions };

--- a/src/store/jwt_api_entreprise/index.js
+++ b/src/store/jwt_api_entreprise/index.js
@@ -69,6 +69,15 @@ const actions = {
       { url: url, params: { email: payload.email } },
       { root: true }
     );
+  },
+
+  retrieveFromMagicLink({ dispatch }, payload) {
+    const url = "jwt_api_entreprise/show_magic_link";
+    return dispatch(
+      "api/admin/get",
+      { url: url, params: { token: payload.token } },
+      { root: true }
+    );
   }
 };
 

--- a/src/store/jwt_api_entreprise/index.js
+++ b/src/store/jwt_api_entreprise/index.js
@@ -60,6 +60,15 @@ const actions = {
       // Default order: by most recent
       commit("fill", orderBy(data, "iat", "desc"));
     });
+  },
+
+  createMagicLink({ dispatch }, payload) {
+    const url = `jwt_api_entreprise/${payload.id}/create_magic_link`;
+    return dispatch(
+      "api/admin/post",
+      { url: url, params: { email: payload.email } },
+      { root: true }
+    );
   }
 };
 


### PR DESCRIPTION
### Contenu de la PR 

* Ajout d'un bouton pour générer un magic link pour un JWT 
* Ajout d'une route / page pour visualiser un JWT à partir d'un magic link 

Je n'ai pas réussi à réutiliser tout le CSS pour la page de visualisation du jeton. Je ne peux pas réutiliser toute la hiérachie de composants existant car ceux-ci requiert que l'utilisateur soit connecté. Il y a donc quelques défauts de style sur la page de visualisation via magic link (cf les captures d'écran ci-dessous) mais rien de moche ni de bloquant je pense que cela peut être déployé en l'état. 

### Quelques captures d'écrans 

#### Bouton "Partager" pour générer un lien 

<img width="1158" alt="Capture d’écran 2021-06-23 à 16 36 05" src="https://user-images.githubusercontent.com/4283958/123117872-6a394400-d442-11eb-8a9e-6e06e817705e.png">

#### Modale où renseigner l'adresse email 

<img width="396" alt="Capture d’écran 2021-06-23 à 16 36 28" src="https://user-images.githubusercontent.com/4283958/123118045-948b0180-d442-11eb-85b9-e6e9f53becad.png">

#### Récupération du jeton via magic link 

<img width="1439" alt="Capture d’écran 2021-06-23 à 16 36 49" src="https://user-images.githubusercontent.com/4283958/123122612-758e6e80-d446-11eb-94ee-81e63e3ab473.png">
